### PR TITLE
Update pci_ids.h for maverick PCIe endpoints

### DIFF
--- a/QDMA/linux-kernel/driver/src/pci_ids.h
+++ b/QDMA/linux-kernel/driver/src/pci_ids.h
@@ -466,6 +466,9 @@ static const struct pci_device_id pci_ids[] = {
 	{ PCI_DEVICE(0x10ee, 0xb158), },	/** PF 1 */
 	{ PCI_DEVICE(0x10ee, 0xb258), },	/** PF 2 */
 	{ PCI_DEVICE(0x10ee, 0xb358), },	/** PF 3 */
+	
+	{ PCI_DEVICE(0x174a, 0x0c66), },        /** PF 0 */
+        { PCI_DEVICE(0x174a, 0x0c67), },        /** PF 1 */
 #endif
 
 	{0,}


### PR DESCRIPTION
Update pci_ids.h for maverick PCIe endpoints

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-STC/Xilinx_qdma_ip_drivers/1)
<!-- Reviewable:end -->
