### PR TITLE
Use the queue id as the port id for the queue, prefetch, and sw context.

### DIFF
--- a/QDMA/DPDK/drivers/net/qdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
@@ -1624,6 +1624,9 @@ static struct qctx_entry eqdma_cpm5_cmpt_ctxt_entries[] = {
 	{"c2h Direction", 0},
 	{"Base Addr Low[5:2]", 0},
 	{"Shared Completion Queue", 0},
+#ifdef RTE_LIBRTE_SPIRENT
+	{"Port ID", 0},
+#endif
 };
 
 static struct qctx_entry eqdma_cpm5_c2h_pftch_ctxt_entries[] = {
@@ -2088,7 +2091,7 @@ static int eqdma_cpm5_indirect_reg_clear(void *dev_hndl,
 		enum ind_ctxt_cmd_sel sel, uint16_t hw_qid)
 {
 	union qdma_ind_ctxt_cmd cmd;
-    
+
     //qdma_log_error("%s: (dev_hndl %p)(sel %d)(hw_qid %d)\n", __func__, dev_hndl, sel, hw_qid);
 
 	qdma_reg_access_lock(dev_hndl);
@@ -2300,6 +2303,9 @@ static void eqdma_cpm5_fill_cmpt_ctxt(struct qdma_descq_cmpt_ctxt
 				EQDMA_CPM5_COMPL_CTXT_BADDR_LOW_MASK,
 				cmpt_ctxt->bs_addr);
 	eqdma_cpm5_cmpt_ctxt_entries[i++].value = cmpt_ctxt->sh_cmpt;
+#ifdef RTE_LIBRTE_SPIRENT
+	eqdma_cpm5_cmpt_ctxt_entries[i++].value = cmpt_ctxt->port_id;
+#endif
 }
 
 /*
@@ -3807,7 +3813,12 @@ static int eqdma_cpm5_cmpt_context_write(void *dev_hndl, uint16_t hw_qid,
 		FIELD_SET(CMPL_CTXT_DATA_W5_BADDR4_LOW_MASK,
 				baddr4_low) |
 		FIELD_SET(CMPL_CTXT_DATA_W5_VIO_EOP_MASK, ctxt->vio_eop) |
+#ifdef RTE_LIBRTE_SPIRENT
+		FIELD_SET(CMPL_CTXT_DATA_W5_SH_CMPT_MASK, ctxt->sh_cmpt) |
+		FIELD_SET(CMPL_CTXT_DATA_W5_PORT_ID_MASK, ctxt->port_id);
+#else
 		FIELD_SET(CMPL_CTXT_DATA_W5_SH_CMPT_MASK, ctxt->sh_cmpt);
+#endif
 
 	return eqdma_cpm5_indirect_reg_write(dev_hndl, sel, hw_qid,
 			cmpt_ctxt, num_words_count);
@@ -3920,6 +3931,10 @@ static int eqdma_cpm5_cmpt_context_read(void *dev_hndl, uint16_t hw_qid,
 			cmpt_ctxt[5]);
 	ctxt->sh_cmpt = (uint8_t)FIELD_GET(CMPL_CTXT_DATA_W5_SH_CMPT_MASK,
 			cmpt_ctxt[5]);
+#ifdef RTE_LIBRTE_SPIRENT
+    ctxt->port_id = (uint8_t)FIELD_GET(CMPL_CTXT_DATA_W5_PORT_ID_MASK,
+			cmpt_ctxt[5]);
+#endif
 
 	ctxt->bs_addr =
 		FIELD_SET(EQDMA_CPM5_COMPL_CTXT_BADDR_HIGH_L_MASK,

--- a/QDMA/DPDK/drivers/net/qdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
@@ -3932,7 +3932,7 @@ static int eqdma_cpm5_cmpt_context_read(void *dev_hndl, uint16_t hw_qid,
 	ctxt->sh_cmpt = (uint8_t)FIELD_GET(CMPL_CTXT_DATA_W5_SH_CMPT_MASK,
 			cmpt_ctxt[5]);
 #ifdef RTE_LIBRTE_SPIRENT
-    ctxt->port_id = (uint8_t)FIELD_GET(CMPL_CTXT_DATA_W5_PORT_ID_MASK,
+	ctxt->port_id = (uint8_t)FIELD_GET(CMPL_CTXT_DATA_W5_PORT_ID_MASK,
 			cmpt_ctxt[5]);
 #endif
 

--- a/QDMA/DPDK/drivers/net/qdma/qdma_access/qdma_access_common.h
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_access/qdma_access_common.h
@@ -45,8 +45,8 @@ extern "C" {
 #define QDMA_HW_VERSION_STRING_LEN			32
 
 #ifdef RTE_LIBRTE_SPIRENT
-/* 
- * despite the documents recommendations, we need this or we get QDMA ctxt errors when dpdkd restarts 
+/*
+ * despite the documents recommendations, we need this or we get QDMA ctxt errors when dpdkd restarts
  * Just make sure the queue base index is correct for cut-thru
  */
 #define ENABLE_INIT_CTXT_MEMORY         1
@@ -435,6 +435,10 @@ struct qdma_descq_cmpt_ctxt {
 	uint8_t vio_eop;
 	/** @sh_cmpt - Shared Completion Queue */
 	uint8_t sh_cmpt;
+#ifdef RTE_LIBRTE_SPIRENT
+	/** @port_id - Port ID */
+	uint8_t port_id;
+#endif
 };
 
 /**
@@ -668,8 +672,8 @@ int qdma_acc_get_num_config_regs(void *dev_hndl, enum qdma_ip_type ip_type,
  */
 
 #ifdef RTE_LIBRTE_SPIRENT
-/* 
- * You can't have functions in a shared memory struct setup by the primary. Each secondary can have a different virtual memory map. 
+/*
+ * You can't have functions in a shared memory struct setup by the primary. Each secondary can have a different virtual memory map.
  * Functions can be at different addresses and must be set during the attach by the secondary process.
  * Whomever did this assumed secondaries were using same binary/libs. STC uses different binaries.
  *

--- a/QDMA/DPDK/drivers/net/qdma/qdma_devops.c
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_devops.c
@@ -383,7 +383,11 @@ int qdma_dev_rx_queue_setup(struct rte_eth_dev *dev, uint16_t rx_queue_id,
 #endif
 
 	rxq->queue_id = rx_queue_id;
+#ifdef RTE_LIBRTE_SPIRENT
+	rxq->port_id = rx_queue_id;
+#else
 	rxq->port_id = dev->data->port_id;
+#endif
 	rxq->func_id = qdma_dev->func_id;
 	rxq->mb_pool = mb_pool;
 	rxq->st_mode = qdma_dev->q_info[rx_queue_id].queue_mode;
@@ -550,7 +554,7 @@ int qdma_dev_rx_queue_setup(struct rte_eth_dev *dev, uint16_t rx_queue_id,
 	if (rxq->st_mode) {
 
         /*
-         * STREAM mode 
+         * STREAM mode
          */
 
 		if (!qdma_dev->dev_cap.st_en) {
@@ -601,7 +605,7 @@ int qdma_dev_rx_queue_setup(struct rte_eth_dev *dev, uint16_t rx_queue_id,
 #ifdef RTE_LIBRTE_SPIRENT
         PMD_DRV_LOG(ERR, "****************************************************************************************");
         PMD_DRV_LOG(ERR, "wb_status (phys address %p)", (void *)((uint64_t)rxq->rx_cmpt_mz->iova + (((uint64_t)rxq->nb_rx_cmpt_desc - 1) *  rxq->cmpt_desc_len)));
-        PMD_DRV_LOG(ERR, "****************************************************************************************");        
+        PMD_DRV_LOG(ERR, "****************************************************************************************");
 #endif
 
 		/* Write-back status structure is the last descriptor in the ring */
@@ -795,7 +799,12 @@ int qdma_dev_tx_queue_setup(struct rte_eth_dev *dev, uint16_t tx_queue_id,
 
 	txq->nb_tx_desc = (nb_tx_desc + 1);
 	txq->queue_id = tx_queue_id;
+#ifdef RTE_LIBRTE_SPIRENT
+	/* We use the port ID to indicate which port the packet is for on the cut-through */
+	txq->port_id = tx_queue_id;
+#else
 	txq->port_id = dev->data->port_id;
+#endif
 	txq->func_id = qdma_dev->func_id;
 	txq->num_queues = dev->data->nb_tx_queues;
 	txq->tx_deferred_start = tx_conf->tx_deferred_start;
@@ -1494,6 +1503,10 @@ int qdma_dev_tx_queue_start(struct rte_eth_dev *dev, uint16_t qid)
 	q_sw_ctxt.wbk_en = 1;
 	q_sw_ctxt.ring_bs_addr = (uint64_t)txq->tx_mz->iova;
 
+#ifdef RTE_LIBRTE_SPIRENT
+	q_sw_ctxt.port_id = qid;
+#endif
+
 	if (txq->en_bypass &&
 		(txq->bypass_desc_sz != 0))
 		q_sw_ctxt.desc_sz = bypass_desc_sz_idx;
@@ -1583,6 +1596,9 @@ int qdma_dev_rx_queue_start(struct rte_eth_dev *dev, uint16_t qid)
 		q_cmpt_ctxt.valid = 1;
 
 #ifdef RTE_LIBRTE_SPIRENT
+		q_prefetch_ctxt.port_id = qid;
+		q_sw_ctxt.port_id = qid;
+
 		// Turn on interrupts for the UIO driver
 		q_cmpt_ctxt.en_int = 1;
 #endif

--- a/QDMA/DPDK/drivers/net/qdma/qdma_devops.c
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_devops.c
@@ -1598,6 +1598,7 @@ int qdma_dev_rx_queue_start(struct rte_eth_dev *dev, uint16_t qid)
 #ifdef RTE_LIBRTE_SPIRENT
 		q_prefetch_ctxt.port_id = qid;
 		q_sw_ctxt.port_id = qid;
+		q_cmpt_ctxt.port_id = qid;
 
 		// Turn on interrupts for the UIO driver
 		q_cmpt_ctxt.en_int = 1;


### PR DESCRIPTION
I put it in all the queue related SW context. Not 100% sure which one the FPGA is looking at.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-STC/Xilinx_qdma_ip_drivers/13)
<!-- Reviewable:end -->
