### PR TITLE
qdma_linux_kernel_driver_update_yocto_5_0

### DIFF
--- a/QDMA/linux-kernel/driver/src/cdev.c
+++ b/QDMA/linux-kernel/driver/src/cdev.c
@@ -780,7 +780,11 @@ int qdma_cdev_device_init(struct qdma_cdev_cb *xcb)
 
 int qdma_cdev_init(void)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 	qdma_class = class_create(THIS_MODULE, QDMA_CDEV_CLASS_NAME);
+#else
+    qdma_class = class_create(QDMA_CDEV_CLASS_NAME);
+#endif
 	if (IS_ERR(qdma_class)) {
 		pr_err("%s: failed to create class 0x%lx.",
 			QDMA_CDEV_CLASS_NAME, (unsigned long)qdma_class);


### PR DESCRIPTION
Xilinx QDMA Linux kernel driver update for Yocto 5.0 Changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-STC/Xilinx_qdma_ip_drivers/14)
<!-- Reviewable:end -->
