### PR TITLE
Use port_id when setting the port value in the qdma_pci_dev object

### DIFF
--- a/QDMA/DPDK/drivers/net/qdma/qdma_ethdev.c
+++ b/QDMA/DPDK/drivers/net/qdma/qdma_ethdev.c
@@ -608,7 +608,11 @@ int qdma_eth_dev_init(struct rte_eth_dev *dev)
 	dma_priv = (struct qdma_pci_dev *)dev->data->dev_private;
 
 #ifdef RTE_LIBRTE_SPIRENT
-    dma_priv->port = dev->port_no;
+	/*
+	 * port_id seems like it is set correctly. Since we're calling rte_eth_dev_pci_generic_probe in
+	 * eth_qdma_pci_probe, port_no is always set to zero.
+	 */
+	dma_priv->port = dev->port_id;
 #endif
 
 	dma_priv->is_vf = 0;


### PR DESCRIPTION
In eth_qdma_pci_probe, rte_eth-dev_pci_generic_probe is called which always sets the port_no value to zero. port_id appears to have the correct value so we use that instead. Fixes issues on LAG where the data structures for the first FPGA was accessed by subsequent FPGAs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-STC/Xilinx_qdma_ip_drivers/17)
<!-- Reviewable:end -->
